### PR TITLE
Fix for #7

### DIFF
--- a/cassiopeia-sqlstore/cassiopeia_sqlstore/league.py
+++ b/cassiopeia-sqlstore/cassiopeia_sqlstore/league.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import foreign, remote, backref
 
 from cassiopeia.dto.league import LeagueListDto, LeaguePositionDto, LeaguePositionsDto
 from cassiopeia.dto.common import DtoObject
-from cassiopeia.data import Tier, Division
+from cassiopeia.data import Tier, Division, Platform
 
 
 from .common import metadata, SQLBaseObject, map_object
@@ -69,6 +69,10 @@ class SQLLeaguePosition(SQLBaseObject):
         dto["rank"] = league_division[int(dto["rank"])]
         if dto["miniSeries"] is None:
             dto.pop("miniSeries")
+        dto["region"] = Platform(self.league.platformId).region
+        dto["leagueName"] = self.league.name
+        dto["queueType"] = self.league.queue
+        dto["tier"] = league_tiers[self.league.tier]
         return dto
 
 map_object(SQLLeaguePosition)

--- a/cassiopeia-sqlstore/cassiopeia_sqlstore/match.py
+++ b/cassiopeia-sqlstore/cassiopeia_sqlstore/match.py
@@ -201,10 +201,10 @@ class SQLMatchParticipantsIdentities(SQLBaseObject):
                     Column("p_platformId", String(5)),
                     Column("match_gameId", BigInteger, primary_key=True),
                     Column("participantId", Integer, primary_key=True),
-                    Column("p_accountId", Integer),
+                    Column("p_accountId", BigInteger),
                     Column("p_summonerName", String),
                     Column("p_summonerId", Integer),                    
-                    Column("p_currentAccountId", Integer),
+                    Column("p_currentAccountId", BigInteger),
                     Column("p_profileIcon", Integer),
                     ForeignKeyConstraint(
                         ["p_currentPlatformId","match_gameId"],

--- a/cassiopeia-sqlstore/cassiopeia_sqlstore/summoner.py
+++ b/cassiopeia-sqlstore/cassiopeia_sqlstore/summoner.py
@@ -9,7 +9,7 @@ class SQLSummoner(SQLBaseObject):
     _table = Table('summoner', metadata,
                 Column('platform', String(length=5), primary_key=True),
                 Column('id', Integer, primary_key=True),
-                Column('accountId', Integer),
+                Column('accountId', BigInteger),
                 Column('name', String(length=30)),
                 Column('summonerLevel', Integer),
                 Column('profileIconId', Integer),


### PR DESCRIPTION
This PR does make changes to the database schema. It won't break existing databases, but the Fix for #7 will only work once the summoner and match tables have been rebuild or the affected columns have been changed manually to BigInteger:
- match_participant_identities.p_accountId
- match_participant_identities.p_currentAccountId
- summoner.accountId

Also includes a little bugfix for edge cases in constants.