### PR TITLE
Fixed TypeError when expiring

### DIFF
--- a/cassiopeia-diskstore/cassiopeia_diskstore/common.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/common.py
@@ -102,7 +102,7 @@ class SimpleKVDiskService(DataSource, DataSink):
         try:
             data, timeout, entered = pickle.loads(self._store.get(key))
             now = datetime.datetime.now().timestamp()
-            if timeout != "forever" and now > entered + timeout:
+            if timeout != "forever" and now > entered + timeout.total_seconds():
                 self._store.delete(key)
                 raise NotFoundError
         except KeyError:


### PR DESCRIPTION
Only a very small change, but expiring the disk store doesn't properly work atm.
```
TypeError: unsupported operand type(s) for +: 'float' and 'datetime.timedelta'
```