### PR TITLE
Added special case to make sqlite work

### DIFF
--- a/cassiopeia-sqlstore/cassiopeia_sqlstore/SQLStore.py
+++ b/cassiopeia-sqlstore/cassiopeia_sqlstore/SQLStore.py
@@ -62,7 +62,11 @@ class SQLStore(DataSource, DataSink):
             if isinstance(value, datetime.timedelta):
                 self._expirations[key] = value.seconds + 24 * 60 * 60 * value.days
         # Create database connection
-        self._engine = create_engine(connection_string, echo=debug, pool_size=pool_size, max_overflow=max_overflow)
+        engine = connection_string.split(":")[0]
+        if engine.lower() == "sqlite":
+            self._engine = create_engine(connection_string, echo=debug)
+        else:
+            self._engine = create_engine(connection_string, echo=debug, pool_size=pool_size, max_overflow=max_overflow)
         metadata.bind = self._engine
         metadata.create_all()
         self._session_factory = sessionmaker(bind=self._engine)


### PR DESCRIPTION
There was a bug which made the sql store not work with sqlite. This was caused because params where passed that sqlalchemy doesn't use for sqllite.
I've fixed it by just adding a check for a sqlite connection string and then not passing those parameters.