### PR TITLE
Updated diskstore to v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+#vscode
+.vscode/

--- a/cassiopeia-diskstore/cassiopeia_diskstore/championmastery.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/championmastery.py
@@ -34,7 +34,7 @@ class ChampionMasteryDiskService(SimpleKVDiskService):
 
     _validate_get_champion_mastery_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").also. \
+        has("summoner.id").as_(str).also. \
         has("champion.id").as_(int)
 
     @get.register(ChampionMasteryDto)
@@ -61,7 +61,7 @@ class ChampionMasteryDiskService(SimpleKVDiskService):
 
     _validate_get_champion_mastery_list_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").as_(int)
+        has("summoner.id").as_(str)
 
     @get.register(ChampionMasteryListDto)
     @validate_query(_validate_get_champion_mastery_list_query, convert_region_to_platform)

--- a/cassiopeia-diskstore/cassiopeia_diskstore/common.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/common.py
@@ -10,7 +10,7 @@ from datapipelines import DataSource, DataSink, PipelineContext, NotFoundError
 from cassiopeia.dto.common import DtoObject
 from cassiopeia.dto.champion import ChampionRotationDto
 from cassiopeia.dto.championmastery import ChampionMasteryDto, ChampionMasteryListDto
-from cassiopeia.dto.league import LeaguePositionsDto, LeagueListDto, MasterLeagueListDto, ChallengerLeagueListDto
+from cassiopeia.dto.league import LeaguePositionsDto, LeagueListDto, MasterLeagueListDto, ChallengerLeagueListDto, GrandmasterLeagueListDto
 from cassiopeia.dto.staticdata import ChampionDto, ChampionListDto, RuneDto, RuneListDto, ItemDto, ItemListDto, SummonerSpellDto, SummonerSpellListDto, MapDto, MapListDto, RealmDto, ProfileIconDataDto, ProfileIconDetailsDto, LanguagesDto, LanguageStringsDto, VersionListDto
 from cassiopeia.dto.match import MatchDto, TimelineDto
 from cassiopeia.dto.summoner import SummonerDto
@@ -67,6 +67,7 @@ class SimpleKVDiskService(DataSource, DataSink):
             LeaguePositionsDto: datetime.timedelta(hours=6),
             LeagueListDto: datetime.timedelta(hours=6),
             ChallengerLeagueListDto: datetime.timedelta(hours=6),
+            GrandmasterLeagueListDto: datetime.timedelta(hours=6),
             MasterLeagueListDto: datetime.timedelta(hours=6),
             MatchDto: -1,
             TimelineDto: -1,

--- a/cassiopeia-diskstore/cassiopeia_diskstore/leagues.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/leagues.py
@@ -87,12 +87,12 @@ class LeaguesDiskService(SimpleKVDiskService):
 
     # Grandmaster
 
-    _validate_get_master_league_query = Query. \
+    _validate_get_grandmaster_league_query = Query. \
         has("platform").as_(Platform).also. \
         has("queue").as_(Queue)
 
     @get.register(GrandmasterLeagueListDto)
-    @validate_query(_validate_get_master_league_query, convert_region_to_platform)
+    @validate_query(_validate_get_grandmaster_league_query, convert_region_to_platform)
     def get_grandmaster_league(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> GrandmasterLeagueListDto:
         key = "{clsname}.{platform}.{queue}".format(clsname=GrandmasterLeagueListDto.__name__,
                                                     platform=query["platform"].value,

--- a/cassiopeia-diskstore/cassiopeia_diskstore/spectator.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/spectator.py
@@ -52,7 +52,7 @@ class SpectatorDiskService(SimpleKVDiskService):
 
     _validate_get_current_game_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").as_(int)
+        has("summoner.id").as_(str)
 
     @get.register(CurrentGameInfoDto)
     @validate_query(_validate_get_current_game_query, convert_region_to_platform)

--- a/cassiopeia-diskstore/cassiopeia_diskstore/summoner.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/summoner.py
@@ -32,8 +32,9 @@ class SummonerDiskService(SimpleKVDiskService):
     ############
 
     _validate_get_summoner_query = Query. \
-        has("id").as_(int). \
-        or_("account.id").as_(int). \
+        has("id").as_(str). \
+        or_("account.id").as_(str). \
+        or_("account.puuid").as_(str). \
         or_("name").as_(str).also. \
         has("platform").as_(Platform)
 
@@ -46,10 +47,11 @@ class SummonerDiskService(SimpleKVDiskService):
         summoner_name = str(summoner_name.encode("utf-8"))
         for key in self._store:
             if key.startswith("SummonerDto."):
-                _, platform, id_, account_id, name = key.split(".")
+                _, platform, id_, account_id, account_puuid, name = key.split(".")
                 if platform == platform_str and any([
                     id_ == str(query.get("id", None)),
                     account_id == str(query.get("account.id", None)),
+                    account_puuid == str(query.get("account.puuid", None)),
                     name == summoner_name
                 ]):
                     return SummonerDto(self._get(key))
@@ -61,9 +63,10 @@ class SummonerDiskService(SimpleKVDiskService):
         platform = Region(item["region"]).platform.value
         name = item["name"].replace(" ", "").lower()
         name = name.encode("utf-8")
-        key = "{clsname}.{platform}.{id}.{account_id}.{name}".format(clsname=SummonerDto.__name__,
+        key = "{clsname}.{platform}.{id}.{account_id}.{puuid}.{name}".format(clsname=SummonerDto.__name__,
                                                                      platform=platform,
                                                                      id=item["id"],
                                                                      account_id=item["accountId"],
+                                                                     puuid=item["puuid"],
                                                                      name=name)
         self._put(key, item)

--- a/cassiopeia-diskstore/cassiopeia_diskstore/summoner.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/summoner.py
@@ -1,5 +1,3 @@
-import base64
-
 from typing import Type, TypeVar, MutableMapping, Any, Iterable
 
 from datapipelines import DataSource, DataSink, PipelineContext, Query, NotFoundError, validate_query


### PR DESCRIPTION
This changes are nessesary to make the diskstore work with v4 of the riot api.
This includes changes to the storage of summoners, leagues and champion mastery endpoint.
It also includes the storage of the new grandmaster league.

Merge after https://github.com/meraki-analytics/cassiopeia/pull/268 is done.