### PR TITLE
Update match history to work with v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 #vscode
 .vscode/
+
+# PyCharm
+.idea/

--- a/cassiopeia-diskstore/cassiopeia_diskstore/match.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/match.py
@@ -43,7 +43,7 @@ class MatchDiskService(SimpleKVDiskService):
 
     @put.register(MatchDto)
     def put_match(self, item: MatchDto, context: PipelineContext = None) -> None:
-        platform = Region(item["region"]).platform.value
+        platform = Platform(item["platformId"]).value
         key = "{clsname}.{platform}.{id}".format(clsname=MatchDto.__name__,
                                                  platform=platform,
                                                  id=item["gameId"])


### PR DESCRIPTION
Note: this is only for match history.

ie. it probably won't close `meraki-analytics/cassiopeia` #384