### PR TITLE
Fix SimpleKVDiskStore pipeline when expirations are set, for Python 3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 #vscode
 .vscode/
+
+# PyCharm
+.idea/

--- a/cassiopeia-diskstore/cassiopeia_diskstore/common.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/common.py
@@ -32,7 +32,7 @@ class SimpleKVDiskService(DataSource, DataSink):
             os.mkdir(path)
         self._store = simplekv.fs.FilesystemStore(path)
         self._expirations = dict(expirations) if expirations is not None else self._default_expirations
-        for key, value in self._expirations.items():
+        for key, value in self._expirations.copy().items():
             if isinstance(key, str):
                 new_key = globals()[key]
                 self._expirations[new_key] = self._expirations.pop(key)

--- a/cassiopeia-diskstore/cassiopeia_diskstore/common.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/common.py
@@ -100,6 +100,8 @@ class SimpleKVDiskService(DataSource, DataSink):
         try:
             data, timeout, entered = pickle.loads(self._store.get(key))
             now = datetime.datetime.now().timestamp()
+            if isinstance(timeout, datetime.timedelta):
+                timeout = timeout.seconds
             if timeout != "forever" and now > entered + timeout:
                 self._store.delete(key)
                 raise NotFoundError

--- a/cassiopeia-diskstore/cassiopeia_diskstore/match.py
+++ b/cassiopeia-diskstore/cassiopeia_diskstore/match.py
@@ -43,7 +43,7 @@ class MatchDiskService(SimpleKVDiskService):
 
     @put.register(MatchDto)
     def put_match(self, item: MatchDto, context: PipelineContext = None) -> None:
-        platform = Region(item["region"]).platform.value
+        platform = Platform(item["platformId"]).value
         key = "{clsname}.{platform}.{id}".format(clsname=MatchDto.__name__,
                                                  platform=platform,
                                                  id=item["gameId"])


### PR DESCRIPTION
The only real change here is in `cassiopeia-diskstore/cassiopeia_diskstore/common.py`, updating it to work on Python 3.12.
The problem only appeared if you were to specify expirations for data.

The linked documentation should have been [here](https://cassiopeia.readthedocs.io/en/latest/plugins.html#simple-kv-disk-store) instead.

---

I'm not clear on if this worked in older versions, it doesn't look like it did even though it looks like there was an attempt at making it work with wrapping the parameter in `dict()` to get a copy.

(580312a was already merged, see: https://github.com/meraki-analytics/cassiopeia-datastores/pull/27). Will have to look at cleaning up this branch later)